### PR TITLE
Added macvlan network to allow for pi-hole DHCP

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -2,6 +2,8 @@
 pihole_hostname: pihole
 pihole_password: change-this-password
 
+pihole_ipaddr: 192.168.1.245  # Ip you want pi-hole to have on your LAN
+
 shelly_plug_enable: false
 shelly_plug_hostname: my-shelly-plug-host-or-ip
 shelly_plug_http_username: username

--- a/example.config.yml
+++ b/example.config.yml
@@ -2,7 +2,7 @@
 pihole_hostname: pihole
 pihole_password: change-this-password
 
-pihole_ipaddr: 192.168.1.245  # Ip you want pi-hole to have on your LAN
+pihole_ipaddr: 192.168.1.245  # Ip you want pi-hole container (not the pi itself) to have on your LAN
 
 shelly_plug_enable: false
 shelly_plug_hostname: my-shelly-plug-host-or-ip

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -12,10 +12,6 @@
   vars:
     ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ ansible_facts['default_ipv4']['netmask'] }}"
 
-- name: CIDR subnet is
-  ansible.builtin.debug:
-    msg: 'Subnet: {{ mask_cidr }}'
-
 - name: Copy Pi-hole docker-compose template to Pi.
   ansible.builtin.template:
     src: templates/pi-hole-docker-compose.yml.j2

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -10,7 +10,7 @@
   set_fact:
     mask_cidr: "{{ ip | ipaddr('prefix') }}"
   vars:
-    ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ansible_facts['default_ipv4']['netmask'] }}"
+    ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ ansible_facts['default_ipv4']['netmask'] }}"
 
 - name: CIDR subnet is
   ansible.builtin.debug:

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -6,6 +6,16 @@
     mode: 0755
   become: false
 
+- name: Get CIDR notation of subnet
+  set_fact:
+    mask_cidr: "{{ ip | ipaddr('prefix') }}"
+  vars:
+    ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ansible_facts['default_ipv4']['netmask'] }}"  
+
+- name: CIDR subnet is
+  ansible.builtin.debug:
+    msg: 'Subnet: {{ mask_cidr }}'
+
 - name: Copy Pi-hole docker-compose template to Pi.
   ansible.builtin.template:
     src: templates/pi-hole-docker-compose.yml.j2

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -10,7 +10,7 @@
   set_fact:
     mask_cidr: "{{ ip | ipaddr('prefix') }}"
   vars:
-    ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ansible_facts['default_ipv4']['netmask'] }}"  
+    ip: "{{ ansible_facts['default_ipv4']['address'] }}/{{ansible_facts['default_ipv4']['netmask'] }}"
 
 - name: CIDR subnet is
   ansible.builtin.debug:

--- a/templates/pi-hole-docker-compose.yml.j2
+++ b/templates/pi-hole-docker-compose.yml.j2
@@ -2,12 +2,29 @@
 ---
 version: "3"
 
+# For DHCP to function pi-hole needs to be able to see/send broadcasts
+# More info at https://docs.pi-hole.net/docker/DHCP/ and
+# http://tonylawrence.com/posts/unix/synology/free-your-synology-ports/
+networks:
+  pihole_network:
+    driver: macvlan
+    driver_opts:
+      parent: eth0
+    ipam:
+      config:
+        - subnet: '{{ ansible_facts['default_ipv4']['address'] }}/{{ mask_cidr }}'
+          gateway: '{{ ansible_facts['default_ipv4']['gateway'] }}'
+
 # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
     hostname: '{{ pihole_hostname }}'
+    networks:
+      pihole_network:
+        ipv4_address: '{{ pihole_ipaddr }}'
+
     ports:
       - "53:53/tcp"
       - "53:53/udp"
@@ -17,7 +34,7 @@ services:
     environment:
       TZ: 'America/Chicago'
       WEBPASSWORD: '{{ pihole_password }}'
-      ServerIP: '{{ ansible_facts['default_ipv4']['address'] }}'
+      ServerIP: '{{ pihole_ipaddr }}' 
     dns:
       - 127.0.0.1
       - 8.8.8.8


### PR DESCRIPTION
Because DHCP is dependent on network broadcasts, the [default bridged network won't work](https://docs.pi-hole.net/docker/DHCP/).

The easiest method would probably just be to set the network mode to host, but then we risk running into port conflicts.
because of this, and because the pi-hole server needs a static IP if it is to act as DHCP server, I decided to instead go for the `macvlan` network driver, which gives the pi-hole container a static IP on the same network as the pi.

I'd like some feedback on how to handle this.
As it stands you need `pip install netaddr` on the ansible controller, as I have the pi-hole task calculate the CIDR mask from the netmask. That could alternatively be provided by the user in the config?

Maybe it should also be optional, and just let people run the default bridged mode if they don't intend to use the DHCP functionality?

