### PR TITLE
Upgrade to bugfixed libseccomp2 on 32bit debian

### DIFF
--- a/tasks/internet-monitoring.yml
+++ b/tasks/internet-monitoring.yml
@@ -1,4 +1,15 @@
 ---
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+  when: ansible_facts['userspace_bits'] == '32'
+
+- name: Upgrade libseccomp2 on 32bit debian systems
+  ansible.builtin.import_tasks: tasks/libseccomp_debian.yml
+  when: ansible_facts['os_family'] == "Debian" and
+        ansible_facts['userspace_bits'] == '32' and
+        ansible_facts.packages['libseccomp2'][0]['version'] is version('2.4.4', '<')
+
 - name: Clone internet-monitoring repo to Pi.
   ansible.builtin.git:
     repo: https://github.com/geerlingguy/internet-monitoring

--- a/tasks/libseccomp_debian.yml
+++ b/tasks/libseccomp_debian.yml
@@ -1,0 +1,20 @@
+---
+- name: Add Buster backports apt key
+  ansible.builtin.apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: '{{ item }}'
+  loop:
+    - 04EE7237B7D453EC
+    - 648ACFD622F3D138
+
+- name: Add Buster backports for fixed libseccomp2
+  ansible.builtin.apt_repository:
+    repo: deb http://httpredir.debian.org/debian buster-backports main contrib non-free
+    state: present
+    filename: debian-backports
+
+- name: Install >libseccomp2.4.4 to fix 32bit issue
+  ansible.builtin.apt:
+    name: libseccomp2
+    state: latest
+    default_release: buster-backports


### PR DESCRIPTION
Speed test was failing on my RPI3 running 32bit raspbian, with an error like:

```
Current thread 0x76f8a390 (most recent call first):
<no Python frame>
Fatal Python error: init_interp_main: can't initialize time
Python runtime state: core initialized
PermissionError: [Errno 1] Operation not permitted
```

A bit of googling and I found this was related to an issue with Focal and Alpine 3.13 based docker images, and the version of libseccomp2 installed.

The fix (on raspbian) is to add the buster backports, as it has a newer fixed version, and upgrade from there, as described in this blog post: https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/
