### PR TITLE
Change pi user to ansible_user from inventory

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -43,7 +43,7 @@
 
 - name: Ensure pi user is added to the docker group.
   ansible.builtin.user:
-    name: pi
+    name: "{{ ansible_user }}"
     groups: docker
     append: true
 

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -41,7 +41,7 @@
     state: present
     executable: pip3
 
-- name: Ensure pi user is added to the docker group.
+- name: Ensure {{ ansible_user }} user is added to the docker group.
   ansible.builtin.user:
     name: "{{ ansible_user }}"
     groups: docker


### PR DESCRIPTION
Changed user name: pi to reference the inventory ansible_user var to allow for users other than pi. As a fix to #29 . Looked for other explicit user declarations but only found this one. 
My first PR, happy for feedback.