### PR TITLE
Fix nested directory structure

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -43,7 +43,7 @@
 
 - name: Ensure pi user is added to the docker group.
   ansible.builtin.user:
-    name: pi
+    name: "{{ ansible_user }}"
     groups: docker
     append: true
 

--- a/tasks/internet-monitoring.yml
+++ b/tasks/internet-monitoring.yml
@@ -13,7 +13,7 @@
 
 - name: Synchronize internet-monitoring directory.
   ansible.posix.synchronize:
-    src: internet-monitoring
+    src: internet-monitoring/
     dest: ~/internet-monitoring
     delete: false
     recursive: true


### PR DESCRIPTION
Adding trailing slash in files task in internet-monitoring.yml to fix nested directories from #36 

Might be configuration/version/OS specific since others haven't noted it?