### PR TITLE
grafana: dns fix

### DIFF
--- a/internet-monitoring/docker-compose.yml
+++ b/internet-monitoring/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
       - 9090:9090
+    dns:
+      - 127.0.0.1
+      - 1.1.1.1
     links:
       - ping:ping
       - speedtest:speedtest


### PR DESCRIPTION
Grafana container crashing 'cause of wrong dns server it's hitting and causing 1000s of dns queries & not be able use internet monitor. might fix https://github.com/geerlingguy/internet-pi/issues/8 https://github.com/geerlingguy/internet-pi/issues/65