### PR TITLE
Update README.md to fix list layout in Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Other features:
 
   1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html). The easiest way (especially on Pi or a Debian system) is via Pip:
      1. (If on Pi/Debian): `sudo apt-get install -y python3-pip`
-     1. (Everywhere): `pip3 install ansible`
+     2. (Everywhere): `pip3 install ansible`
   2. Install requirements: `ansible-galaxy collection install -r requirements.yml`
   3. Make copies of the following files and customize them to your liking:
-    - `example.inventory.ini` to `inventory.ini` (replace IP address with your Pi's IP, or comment that line and uncomment the `connection=local` line if you're running it on the Pi you're setting up).
-    - `example.config.yml` to `config.yml`
+     - `example.inventory.ini` to `inventory.ini` (replace IP address with your Pi's IP, or comment that line and uncomment the `connection=local` line if you're running it on the Pi you're setting up).
+     - `example.config.yml` to `config.yml`
   4. Run the playbook: `ansible-playbook main.yml`
 
 > **If running locally on the Pi**: You may encounter an error like "Error while fetching server API version". If you do, please either reboot or log out and log back in, then run the playbook again.


### PR DESCRIPTION
The README.md contained a small layout error in the Setup section. The list items in the third point ("Make copies of...") did not display correctly, which is fixed now.
I also changed the numbering scheme under point one ("Install Ansible").