### PR TITLE
Script to download and deploy new container images

### DIFF
--- a/internet-monitoring/prometheus/pinghosts.yml
+++ b/internet-monitoring/prometheus/pinghosts.yml
@@ -3,4 +3,3 @@
     - http://www.google.com/;google.com
     - https://github.com/;github.com
     - https://www.apple.com/;apple.com
-    - https://1.1.1.1/;1.1.1.1

--- a/internet-monitoring/prometheus/pinghosts.yml
+++ b/internet-monitoring/prometheus/pinghosts.yml
@@ -1,0 +1,6 @@
+---
+- targets:
+    - http://www.google.com/;google.com
+    - https://github.com/;github.com
+    - https://www.apple.com/;apple.com
+    - https://1.1.1.1/;1.1.1.1

--- a/internet-monitoring/prometheus/pinghosts.yml
+++ b/internet-monitoring/prometheus/pinghosts.yml
@@ -1,5 +1,0 @@
----
-- targets:
-    - http://www.google.com/;google.com
-    - https://github.com/;github.com
-    - https://www.apple.com/;apple.com

--- a/upgrade-container.sh
+++ b/upgrade-container.sh
@@ -1,0 +1,24 @@
+#Script to update and upgrade pi-hole and internet-monitoring containers
+
+
+#Moves into the pi-hole directory
+cd ~/pi-hole
+
+#Pulls the latest images
+docker-compose pull
+
+#Restarts the necessary containers with newer images
+docker-compose up -d --no-deps
+
+#Moves to the internet-monitoring directory
+cd ..
+cd ~/internet-monitoring
+
+#Pulls the latest images
+docker-compose pull
+
+#Restarts the necessary containers with newer images
+docker-compose up -d --no-deps
+
+#Delets unused/deprecated container images
+docker system prune -f


### PR DESCRIPTION
Partially resolves issue #7 with creating an upgrade script to deploy new containers for both the Pi-Hole and Internet-Monitoring directories;  This does **_not_** cover the second part of the issue with backing up the Pi-Hole configuration files (perhaps to be created in a separate script).

I currently have this shell script running in a cron job every seven (7) days, assuming there isn't an emergent/critical update.