### PR TITLE
Fix Speedtest-Exporter select ServerID to test

### DIFF
--- a/internet-monitoring/docker-compose.yml
+++ b/internet-monitoring/docker-compose.yml
@@ -63,8 +63,6 @@ services:
       - back-tier
 
   speedtest:
-    tty: true
-    stdin_open: true
     expose:
       - 9798
     ports:


### PR DESCRIPTION
If `tty` and `stdin_open` are enabled when the ServerID is selected it won't work.

Issue: https://github.com/MiguelNdeCarvalho/speedtest-exporter/issues/88