### PR TITLE
Added restart ssh session directions to setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It should also work with Ubuntu for Pi, or Arch Linux, but has not been tested o
      2. (Everywhere): `pip3 install ansible`
   2. Clone this repository: `git clone https://github.com/geerlingguy/internet-pi.git`, then enter the repository directory: `cd internet-pi`.
   3. Install requirements: `ansible-galaxy collection install -r requirements.yml`
+  > **Note**: If you receive the error "ansible-galaxy: command not found" and you are confident that you've installed `ansible` (Step 1), simply restart your bash or SSH session.
   4. Make copies of the following files and customize them to your liking:
      - `example.inventory.ini` to `inventory.ini` (replace IP address with your Pi's IP, or comment that line and uncomment the `connection=local` line if you're running it on the Pi you're setting up).
      - `example.config.yml` to `config.yml`


### PR DESCRIPTION
People reading through these steps that are unfamiliar with bash/SSH will not understand that `ansible` will not be available until the session is restarted.

I don't know if the language I've added is the best, but thought I'd open a PR rather than an issue to make discussion easier.