### PR TITLE
Pi 3 model B+ fix. Described in README due to many suggested solutions. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It should also work with Ubuntu for Pi, or Arch Linux, but has not been tested o
 
 > **Pi 3 model B+** require an addtional step for Internet Monitoring. 
 > - Enter the `internet-monitoring` directory and run `docker-compose up -d`. 
-> - Allow the to complete then you can retry `ansible-playbook main.yml` in the `internet-pi` directory. 
+> - Allow this to complete then you can retry `ansible-playbook main.yml` in the `internet-pi` directory. 
 > 
 > Thanks to [duongnosu](https://github.com/geerlingguy/internet-pi/issues/150#issuecomment-885074468) for this solution.
 


### PR DESCRIPTION
After receiving this error myself I went looking though the issues to find how others had fixed it. A few suggestions appeared and this one seemed the most elegant. 

Fix for bug : 
```
TASK [Ensure internet-monitoring environment is running.] **********************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Error connecting: Error while fetching server API version: ('Connection aborted.', PermissionError(13, 'Permission denied'))"}
```