### PR TITLE
Add `rsync` requirement for HypriotOS support

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -33,6 +33,7 @@
       - python3-dev
       - python3-pip
       - git
+      - rsync
     state: present
   when: ansible_facts.os_family == "Debian"
 


### PR DESCRIPTION
Hypriot lacks `rsync` by default, makes sense to assert its presence