### PR TITLE
Add rsync to Arch dependencies

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -45,6 +45,7 @@
       - base-devel
       - python-pip
       - git
+      - rsync
     state: present
   when: ansible_facts.os_family == "Archlinux"
 


### PR DESCRIPTION
Add missing rsync to Arch dependencies, should fix Issue #158 which was partially fixed by #270 for Debian only.