### PR TITLE
expose configuration of pi-hole `BLOCK_ICLOUD_PR` (blocking of Apple's Private Relay)

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -7,6 +7,10 @@ pihole_enable: true
 pihole_hostname: pihole
 pihole_timezone: America/Chicago
 pihole_password: "change-this-password"
+# Block Apple's iCloud Private Relay by default
+# - Prevent Apple devices from bypassing Pi-hole
+# - See also: Pi-hole configuration 'BLOCK_ICLOUD_PR'
+pihole_block_icloud_pr: true
 
 # Internet monitoring configuration.
 monitoring_enable: true

--- a/templates/pi-hole-docker-compose.yml.j2
+++ b/templates/pi-hole-docker-compose.yml.j2
@@ -18,6 +18,7 @@ services:
       TZ: '{{ pihole_timezone }}'
       WEBPASSWORD: '{{ pihole_password }}'
       ServerIP: '{{ ansible_facts['default_ipv4']['address'] }}'
+      FTLCONF_BLOCK_ICLOUD_PR: '{{ pihole_block_icloud_pr }}'
     dns:
       - 127.0.0.1
       - 8.8.8.8


### PR DESCRIPTION
**What and Why?**

Make it possible to disable the default blocking of Apple's Private Relay so that the pi-hole can be used as DNS in a Network with Apple devices that use the Private Relay. Without that setting Private Relay would need to be disabled on the devices for the affected connection.

See also: [pi-hole config](https://docs.pi-hole.net/ftldns/configfile/#icloud_private_relay)

**How**

- The pi-hole setting `BLOCK_ICLOUD_PR` is now exposed to `example.config.yml` as `pihole_block_icloud_pr`
   - Implemented by setting the docker environment variable 'FTLCONF_BLOCK_ICLOUD_PR'
      - See also: [docker-pi-hole advanced variables](https://github.com/pi-hole/docker-pi-hole#advanced-variables)
