### PR TITLE
enable use of multiple shelly plugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ So that's what this is.
 
 Other features:
 
-  - **Shelly Plug Monitoring**: Installs a [`shelly-plug-prometheus` exporter](https://github.com/geerlingguy/shelly-plug-prometheus) and a Grafana dashboard, which tracks and displays power usage on a Shelly Plug running on the local network. (Disabled by default. Enable and configure using the `shelly_plug_*` vars in `config.yml`.)
+  - **Shelly Plug Monitoring**: Installs a [`shelly-plug-prometheus` exporter](https://github.com/geerlingguy/shelly-plug-prometheus) and a Grafana dashboard, which tracks and displays power usage on one or more Shelly Plugs running on the local network. (Disabled by default. Enable and configure using the `shelly_plugs_*` vars in `config.yml`.)
   - **AirGradient Monitoring**: Configures [`airgradient-prometheus`](https://github.com/geerlingguy/airgradient-prometheus) and a Grafana dashboard, which tracks and displays air quality over time via one or more AirGradient DIY monitors. (Disabled by default. Enable and configure using the `airgradient_enable` var in `config.yml`. See example configuration for ability to monitor multiple AirGradient DIY stations.)
   - **Starlink Monitoring**: Installs a [`starlink` prometheus exporter](https://github.com/danopstech/starlink_exporter) and a Grafana dashboard, which tracks and displays Starlink statistics. (Disabled by default. Enable and configure using the `starlink_enable` var in `config.yml`.)
 

--- a/example.config.yml
+++ b/example.config.yml
@@ -19,10 +19,13 @@ monitoring_ping_hosts:  # [URL];[HUMAN_READABLE_NAME]
   - https://www.apple.com/;apple.com
 
 # Shelly Plug configuration. (Also requires `monitoring_enable`)
-shelly_plug_enable: false
-shelly_plug_hostname: my-shelly-plug-host-or-ip
-shelly_plug_http_username: username
-shelly_plug_http_password: "password"
+shelly_plugs_enable: false
+shelly_plugs:           # list of Shelly Plugs to connect to
+  - name: my-shelly-plug   # will show up in dashboard to identify this plug
+    hostname: "my-shelly-plug-host-or-ip"
+    port: 9924
+shelly_plugs_http_username: username
+shelly_plugs_http_password: "password"
 
 # AirGradient configuration. (Also requires `monitoring_enable`)
 airgradient_enable: false

--- a/files/power-consumption.json
+++ b/files/power-consumption.json
@@ -8,25 +8,33 @@
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
         "type": "dashboard"
       }
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "datasource": "prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 500,
           "min": 0,
@@ -59,6 +67,7 @@
       },
       "id": 6,
       "options": {
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -70,7 +79,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.2",
       "targets": [
         {
           "datasource": {
@@ -89,13 +98,15 @@
       "type": "gauge"
     },
     {
-      "datasource": "prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "max": 500,
           "min": 0,
@@ -128,6 +139,7 @@
       },
       "id": 4,
       "options": {
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -139,7 +151,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.4.5",
+      "pluginVersion": "8.4.2",
       "targets": [
         {
           "datasource": {
@@ -158,110 +170,111 @@
       "type": "gauge"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "prometheus",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
       "description": "",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "always",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 2000
+              },
+              {
+                "color": "dark-red",
+                "value": 2500
+              }
+            ]
+          },
           "unit": "watt"
         },
         "overrides": []
       },
-      "fill": 1,
-      "fillGradient": 0,
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 24,
         "x": 0,
         "y": 8
       },
-      "hiddenSeries": false,
       "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
       "options": {
-        "alertThreshold": true
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "percentage": false,
-      "pluginVersion": "7.4.5",
-      "pointradius": 1,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "8.4.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "exemplar": true,
           "expr": "power",
           "interval": "",
-          "legendFormat": "Watts",
+          "legendFormat": "{{job}}",
           "queryType": "randomWalk",
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Power Consumption",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "$$hashKey": "object:169",
-          "decimals": null,
-          "format": "watt",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "$$hashKey": "object:170",
-          "decimals": null,
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     }
   ],
   "refresh": "5m",
-  "schemaVersion": 27,
+  "schemaVersion": 35,
   "style": "dark",
   "tags": [
     "power"
@@ -277,5 +290,6 @@
   "timezone": "",
   "title": "Power consumption",
   "uid": "i_aeo-uMz",
-  "version": 3
+  "version": 1,
+  "weekStart": ""
 }

--- a/files/power-consumption.json
+++ b/files/power-consumption.json
@@ -73,9 +73,14 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "exemplar": false,
           "expr": "power",
           "interval": "",
-          "legendFormat": "Watts",
+          "legendFormat": "{{job}}",
           "queryType": "randomWalk",
           "refId": "A"
         }
@@ -137,9 +142,14 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "exemplar": false,
           "expr": "power",
           "interval": "",
-          "legendFormat": "Watts",
+          "legendFormat": "{{job}}",
           "queryType": "randomWalk",
           "refId": "A"
         }

--- a/main.yml
+++ b/main.yml
@@ -40,7 +40,7 @@
 
     - name: Set up Shelly Plug Monitoring.
       ansible.builtin.import_tasks: tasks/shelly-plug.yml
-      when: shelly_plug_enable
+      when: shelly_plugs_enable
 
     - name: Set up Air Gradient Monitoring.
       ansible.builtin.import_tasks: tasks/airgradient.yml

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -22,12 +22,14 @@ scrape_configs:
     static_configs:
       - targets: ['speedtest:9798']
 
-{% if shelly_plug_enable %}
-  - job_name: 'shelly-plug'
+{% if shelly_plugs_enable %}
+{% for plug in shelly_plugs %}
+  - job_name: '{{ plug.name }}'
     metrics_path: /metrics
     scrape_interval: 1m
     static_configs:
-      - targets: ['172.17.0.1:9924']
+      - targets: ['172.17.0.1:{{ plug.port }}']
+{% endfor %}
 {% endif %}
 
 {% if airgradient_enable %}

--- a/templates/shelly-plug-docker-compose.yml.j2
+++ b/templates/shelly-plug-docker-compose.yml.j2
@@ -3,15 +3,17 @@
 version: "3"
 
 services:
-  shelly-plug:
-    container_name: shelly-plug
+{% for plug in shelly_plugs %}
+  shelly-plug-{{ plug.name }}:
+    container_name: shelly-plug-{{ plug.name }}
     image: php:8-apache
     ports:
-      - "9924:80"
+      - "{{ plug.port }}:80"
     environment:
-      SHELLY_HOSTNAME: '{{ shelly_plug_hostname }}'
-      SHELLY_HTTP_USERNAME: '{{ shelly_plug_http_username }}'
-      SHELLY_HTTP_PASSWORD: '{{ shelly_plug_http_password }}'
+      SHELLY_HOSTNAME: '{{ plug.hostname }}'
+      SHELLY_HTTP_USERNAME: '{{ shelly_plugs_http_username }}'
+      SHELLY_HTTP_PASSWORD: '{{ shelly_plugs_http_password }}'
     volumes:
       - './:/var/www/html'
     restart: unless-stopped
+{% endfor %}


### PR DESCRIPTION
This also includes some changes to the dashboard (to make the names of the plugs show up on the board), migrating the time series panel while doing so.
Please note the change from singular to plural in the variable names, which might make it harder to merge changes for others, but it felt to me like the right thing to do.