### PR TITLE
enable pinging ipv6-only hosts (off by default)

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -2,6 +2,12 @@
 # Location where configuration files will be stored.
 config_dir: '~'
 
+# IPv6 configuration: You can specify your desired subnet for docker-compose here.
+# If you change these settings, you must tear down any existing containers first so the network is created from scratch
+docker_ipv6_enable: false
+docker_ipv6_subnet: 2001:3984:3989::/64
+docker_ipv6_gateway: 2001:3984:3989::1
+
 # Pi-hole configuration.
 pihole_enable: true
 pihole_hostname: pihole

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -34,6 +34,7 @@
       - python3-pip
       - git
       - rsync
+      - iptables-persistent
     state: present
   when: ansible_facts.os_family == "Debian"
 
@@ -60,6 +61,31 @@
     name: "{{ ansible_user }}"
     groups: docker
     append: true
+
+- name: Load routing rules to allow access to IPv6 hosts (Debian).
+  ansible.builtin.blockinfile:
+    block: "{{ lookup('template', 'templates/ip6tables.rules.j2') }}"
+    dest: /etc/iptables/rules.v6
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR IPV6 ROUTING"
+    validate: ip6tables-restore %s
+    mode: 0644
+  become: true
+  when:
+    - docker_ipv6_enable
+    - ansible_facts.os_family == "Debian"
+
+- name: Load routing rules to allow access to IPv6 hosts (Archlinux).
+  # TODO: the implementation for Archlinux has not been tested
+  ansible.builtin.blockinfile:
+    block: "{{ lookup('template', 'templates/ip6tables.rules.j2') }}"
+    dest: /etc/iptables/iptables.rules
+    marker: "# {mark} ANSIBLE MANAGED BLOCK FOR IPV6 ROUTING"
+    validate: ip6tables-restore %s
+    mode: 0644
+  become: true
+  when:
+    - docker_ipv6_enable
+    - ansible_facts.os_family == "Archlinux"
 
 # reset_connection doesn't support conditionals.
 - name: Reset connection so docker group is picked up.

--- a/tasks/internet-monitoring.yml
+++ b/tasks/internet-monitoring.yml
@@ -33,6 +33,8 @@
     dest: "{{ config_dir }}/internet-monitoring/{{ item.dest }}"
     mode: 0644
   loop:
+    - src: docker-compose.yml.j2
+      dest: docker-compose.yml
     - src: grafana-config.monitoring.j2
       dest: grafana/config.monitoring
     - src: prometheus.yml.j2

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -8,6 +8,20 @@ volumes:
 networks:
   front-tier:
   back-tier:
+{% if docker_ipv6_enable %}
+    enable_ipv6: true
+    driver: bridge
+    driver_opts:
+      com.docker.network.enable_ipv6: "true"
+    ipam:
+      config:
+       - subnet: {{ docker_ipv6_subnet }}
+         gateway: {{ docker_ipv6_gateway }}
+{% else %}
+    enable_ipv6: false
+    driver_opts:
+      com.docker.network.enable_ipv6: "false"
+{% endif %}
 
 services:
   prometheus:

--- a/templates/ip6tables.rules.j2
+++ b/templates/ip6tables.rules.j2
@@ -1,0 +1,8 @@
+# rules to allow addressing hosts via IPv6 from the docker containers
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+-A POSTROUTING -s {{ docker_ipv6_subnet }} ! -o docker0 -j MASQUERADE
+COMMIT


### PR DESCRIPTION
I did my best to set up docker-compose for IPv6.
It is disabled by default because I don't know if it has negative impact on people without an IPv6 address (it shouldn't, but I'm no expert, and can't test it), and it doesn't bring any benefit as long as all hosts you want to check can be reached via IPv4.

One thing I couldn't make work is updating the back-tier network if it already exists on the client. docker-compose seems to only be able to create/delete docker networks, not modify existing ones that are currently in use.
Workaround: User has to manually `docker-compose down` (or stop each container to then manually delete the network) before setting `docker_ipv6_enable` to true and running the playbook.

There's also a big open question: unlike for IPv4, which just works out of the box, docker-compose needs you to specify an IPv6 subnet and to set up a routing rule for it. As I was following an example from the Internet, I just used the same subnet `2001:3984:3989::/64`, but is that a reasonable default? I have no idea. I did make it configurable, so anyone running into problems will have the tools to deal with them.

This feature is entirely untested on Archlinux. It is implemented according to the documentation I found, so it has a good chance to work, but that's it.

This PR is related to #347 and should help people encountering the same issues in fixing it.