### PR TITLE
add ddclient

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -18,6 +18,14 @@ monitoring_ping_hosts:  # [URL];[HUMAN_READABLE_NAME]
   - https://github.com/;github.com
   - https://www.apple.com/;apple.com
 
+# DDclient configuration (A records for hosts must already exist)
+ddclient_protocol: cloudflare
+ddclient_login: my-cloudflare-login-email-address
+# Cloudflare Global API Key can be generated here: https://dash.cloudflare.com/profile/api-tokens
+ddclient_password: my-cloudflare-global-api-key
+ddclient_zone: mydomain.com
+ddclient_hosts: grafana.mydomain.com,pihole.mydomain.com
+
 # Shelly Plug configuration. (Also requires `monitoring_enable`)
 shelly_plug_enable: false
 shelly_plug_hostname: my-shelly-plug-host-or-ip

--- a/internet-monitoring/docker-compose.yml
+++ b/internet-monitoring/docker-compose.yml
@@ -89,3 +89,13 @@ services:
       - "^/(sys|proc|dev|host|etc|rootfs/var/lib/docker/containers|rootfs/var/lib/docker/overlay2|rootfs/run/docker/netns|rootfs/var/lib/docker/aufs)($$|/)"
     networks:
       - back-tier
+
+  ddclient:
+    image: linuxserver/ddclient:latest
+    container_name: ddclient
+    networks:
+      - back-tier
+    volumes:
+      - ./ddclient:/config
+    restart: unless-stopped
+    pull_policy: always

--- a/tasks/internet-monitoring.yml
+++ b/tasks/internet-monitoring.yml
@@ -39,6 +39,8 @@
       dest: prometheus/prometheus.yml
     - src: prometheus-pinghosts.yaml.j2
       dest: prometheus/pinghosts.yaml
+    - src: ddclient.conf.j2
+      dest: ddclient/ddclient.conf
   notify: Restart internet-monitoring
   become: false
 

--- a/templates/ddclient.conf.j2
+++ b/templates/ddclient.conf.j2
@@ -1,0 +1,14 @@
+daemon=300				# check every 300 seconds
+syslog=yes				# log update msgs to syslog
+#mail=root				# mail all msgs to root
+#mail-failure=root			# mail failed update msgs to root
+pid=/var/run/ddclient/ddclient.pid		# record PID in file.
+ssl=yes 				# use ssl-support
+
+## CloudFlare
+protocol={{ ddclient_protocol }}
+use=web
+login={{ ddclient_login }}
+password={{ ddclient_password }}
+zone={{ ddclient_zone }}
+{{ ddclient_hosts }}


### PR DESCRIPTION
Adds ddclient docker container to update A records hosted in Cloudflare. This will change the value of an A record to the public IP address used by your Internet Monitoring device. This is useful if your Internet Monitor is at a remote location with a dynamic IP address and you would like to set up remote access.