### PR TITLE
Fixes #388: disable systemd-resolved stub listener on Ubuntu

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -7,6 +7,7 @@ pihole_enable: true
 pihole_hostname: pihole
 pihole_timezone: America/Chicago
 pihole_password: "change-this-password"
+pihole_systemd_resolved_dns: "1.1.1.1"
 
 # Internet monitoring configuration.
 monitoring_enable: true

--- a/tasks/handlers.yml
+++ b/tasks/handlers.yml
@@ -26,3 +26,9 @@
     build: false
     restarted: true
   become: false
+
+- name: Restart systemd-resolved
+  ansible.builtin.systemd:
+    name: systemd-resolved.service
+    state: restarted
+  become: true

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -1,4 +1,11 @@
 ---
+
+- name: Disable systemd-resolved stub listener (Ubuntu 17.10+).
+  ansible.builtin.import_tasks: tasks/ubuntu-disable-dns-stub-listener.yml
+  when:
+    - ansible_facts['distribution'] == "Ubuntu"
+    - ansible_facts['lsb']['release'] | int >= 17.10
+
 - name: Create Pi-hole folder on Pi.
   ansible.builtin.file:
     path: "{{ config_dir }}/pi-hole"

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -6,6 +6,9 @@
     - ansible_facts['distribution'] == "Ubuntu"
     - ansible_facts['lsb']['release'] | int >= 17.10
 
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+
 - name: Create Pi-hole folder on Pi.
   ansible.builtin.file:
     path: "{{ config_dir }}/pi-hole"

--- a/tasks/ubuntu-disable-dns-stub-listener.yml
+++ b/tasks/ubuntu-disable-dns-stub-listener.yml
@@ -1,0 +1,19 @@
+---
+# For more information:
+# https://github.com/pi-hole/docker-pi-hole#installing-on-ubuntu
+
+- name: Copy systemd-resolved conf template to Pi.
+  ansible.builtin.template:
+    src: templates/pi-hole-ubuntu-systemd-resolved.conf.j2
+    dest: /etc/systemd/resolved.conf
+    mode: 0644
+  become: true
+  notify: Restart systemd-resolved
+
+- name: Ensure resolv.conf is linked
+  ansible.builtin.file:
+    src: /run/systemd/resolve/resolv.conf
+    dest: /etc/resolv.conf
+    state: link
+    force: true
+  notify: Restart systemd-resolved

--- a/templates/pi-hole-ubuntu-systemd-resolved.conf.j2
+++ b/templates/pi-hole-ubuntu-systemd-resolved.conf.j2
@@ -1,0 +1,26 @@
+# {{ ansible_managed }}
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS={{ pihole_systemd_resolved_dns }}
+#FallbackDNS=
+#Domains=
+#LLMNR=no
+#MulticastDNS=no
+#DNSSEC=no
+#DNSOverTLS=no
+#Cache=no-negative
+DNSStubListener=no
+#ReadEtcHosts=yes


### PR DESCRIPTION
Addresses the steps necessary to get Docker Pi-Hole working on a Docker host running Ubuntu 17.10 or later and closes #388.

Presumably this PR could also provide a working Docker Pi-Hole on other distros where [systemd v229][1] or later is the init system and `systemd-resolved` has the `DNSStubListener=yes` enabled in `/etc/systemd/resolved.conf`. However, I have only tested this on a fresh instance of Ubuntu 20.04.4 LTS in a virtual machine and Ubuntu 22.04 LTS on a Raspberry Pi 3 Model B.

This PR introduces a new variable `pihole_systemd_resolved_dns` in `example.config.yml` that sets the upstream DNS provider in `/etc/systemd/resolv.conf`.

[1]: https://lists.freedesktop.org/archives/systemd-devel/2016-February/035748.html