### PR TITLE
maxDataPoints of grafana metrics reduced to 10000 to ensure …

### DIFF
--- a/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
+++ b/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
@@ -62,7 +62,7 @@
       "id": 8,
       "interval": null,
       "links": [],
-      "maxDataPoints": 50000,
+      "maxDataPoints": 10000,
       "options": {
         "orientation": "horizontal",
         "reduceOptions": {
@@ -133,7 +133,7 @@
       "id": 10,
       "interval": null,
       "links": [],
-      "maxDataPoints": 50000,
+      "maxDataPoints": 10000,
       "options": {
         "orientation": "horizontal",
         "reduceOptions": {
@@ -205,7 +205,7 @@
       "id": 12,
       "interval": null,
       "links": [],
-      "maxDataPoints": 50000,
+      "maxDataPoints": 10000,
       "options": {
         "orientation": "horizontal",
         "reduceOptions": {
@@ -288,7 +288,7 @@
       },
       "id": 6,
       "links": [],
-      "maxDataPoints": 50000,
+      "maxDataPoints": 10000,
       "options": {
         "graph": {},
         "legend": {


### PR DESCRIPTION
**maxDataPoints of grafana metrics reduced to 10000 to ensure dashboard does not run into prometheus bad_data error**

This error occured to me on a fresh installation after some days of running: 
![FireShot Capture 012 - Internet connection - Grafana - 10 0 0 39](https://user-images.githubusercontent.com/1956146/170942408-1c55787c-e8af-43d9-86f6-428fca7396ec.png)

I assume that the collected data at some point reaches the hardcoded limit of prometheus:
"bad_data: exceeded maximum resolution of 11,000 points per timeseries."
https://github.com/prometheus/prometheus/issues/2253
Alternatively we could configure prometheus to accept queries with more datapoints, but I think this pull-request is the more straight-forward solution.

**This error occoured to me when the time range of the dashboard was set to 7days (default).** 
Editing the metrics and setting the max-data-points manually from 50000 to 10000 did the trick for me:
![FireShot Capture 014 - Internet connection - Grafana - 10 0 0 39](https://user-images.githubusercontent.com/1956146/170942420-0715bf7e-97c8-4648-934b-fef7ec99558f.png)
![FireShot Capture 013 - Internet connection - Grafana - 10 0 0 39](https://user-images.githubusercontent.com/1956146/170942419-850925f0-ec76-43b8-a8de-a29f365d3c9f.png)

After this the dashboard worked as intened. So IMHO this can be a problem for everyone who uses intenet-pi longer than a couple of days. Therefore I provided a long term fix in the means of reducing the max-data-points to 10000 in the internet-connection.json

Please merge :)

(This is my second pull-request on github, if anything is not according to the procedure, let me know)