### PR TITLE
Update example monitoring_ping_hosts

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -21,9 +21,10 @@ monitoring_grafana_admin_password: "admin"
 monitoring_speedtest_interval: 60m
 monitoring_ping_interval: 5s
 monitoring_ping_hosts:  # [URL];[HUMAN_READABLE_NAME]
-  - http://www.google.com/;google.com
-  - https://github.com/;github.com
-  - https://www.apple.com/;apple.com
+  - https://www.google.com/;google.com
+  - https://www.speedtest.net/;speedtest
+  - https://status.aws.amazon.com/;AWS status
+  - https://www.akamaistatus.com/;Akamai status
 
 # Shelly Plug configuration. (Also requires `monitoring_enable`)
 shelly_plug_enable: false


### PR DESCRIPTION
Add more connectivity-oriented domains for the ping hosts in the monitoring config example:
- Remove github and apple, make google HTTPS
- Add speedtest
- Add AWS and Akamai status hosts