### PR TITLE
add template conditional around the pihole exporter

### DIFF
--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -72,10 +72,11 @@ scrape_configs:
   - job_name: 'node'
     static_configs:
       - targets: {{ prometheus_node_exporter_targets | to_yaml }}
-
+  {% if pihole_enable %}
   - job_name: 'pihole-exporter'
     static_configs:
       - targets: ['pihole:9617']
+  {% endif %}
 
 {% filter indent(width=2,first=True) %}
 {{ prometheus_extra_scrape_configs }}


### PR DESCRIPTION
Thanks for the repo, this was very helpful for getting my setup off the ground.

I initially set this up without pihole disabled. When I checked out the prometheus targets page (http://localhost:9090/targets), I noticed the pihole exporter was configured and was failing to connect to the exporter.

<img width="887" alt="Screen Shot 2022-10-12 at 9 30 46 PM" src="https://user-images.githubusercontent.com/3848371/195501989-b1303211-1937-44f4-9de6-2910ff2ffe7f.png">

After adding the conditional:

<img width="882" alt="Screen Shot 2022-10-12 at 9 35 21 PM" src="https://user-images.githubusercontent.com/3848371/195502584-2692ea05-296b-4420-a902-a8ee248576a1.png">
