### PR TITLE
Ubuntu uses a managed resolv.conf, we can't just edit it directly

### DIFF
--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -27,6 +27,7 @@
     line: "name_servers=127.0.0.1"
     dest: "/etc/resolvconf.conf"
     regexp: "^#?name_servers="
+  when: ansible_facts.distribution != "Ubuntu"
   register: resolvconf_file
 
 - name: Regenerate resolvconf if file is changed.


### PR DESCRIPTION
Don't try to update resolv.conf on ubuntu because it's managed by systemd-resolve, and it makes it sad.

To do it properly it requires modifications to the `/etc/netplan/xyz.yaml` where you have set up the machines config, and we can't assert that without knowing more about the destination model. For example a netplan that looks like this:

```
network:
  version: 2
  renderer: networkd
  ethernets:
    eth0:
      dhcp4: false
      dhcp6: false
      ipv6-privacy: true
      addresses:
        - 192.168.0.5/24 # Update as appropriate. 
      routes:
        - to: default
          via: 192.168.10.1
      nameservers:
          addresses: [127.0.0.1] # update to wherever we want dns to resolve. For pi-hole, probably localhost. 
```