### PR TITLE
Enabled the selection of cloudflare speedtest 

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -19,6 +19,7 @@ pihole_password: "change-this-password"
 monitoring_enable: true
 monitoring_grafana_admin_password: "admin"
 monitoring_speedtest_interval: 60m
+monitoring_speedtest_provider: ookla  # changeable to ookla or cloudflare
 monitoring_ping_interval: 5s
 monitoring_ping_hosts:  # [URL];[HUMAN_READABLE_NAME]
   - http://www.google.com/;google.com

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -97,7 +97,11 @@ services:
       - 9798
     ports:
       - 9798:9798
+{% if monitoring_speedtest_provider == 'cloudflare' %}
+    image: redorbluepill/cloudflare-speedtest-exporter
+{% else %}
     image: miguelndecarvalho/speedtest-exporter
+{% endif %}
     restart: always
     networks:
       - back-tier


### PR DESCRIPTION
Update to closed pull request #387.

Created a new Docker image called `redorbluepill/cloudflare-speedtest-exporter` to replace the current Ookla Speedtest Prometheus Exporter and enabled the selection of the speedtest images through a variable called `monitoring_speedtest_provider` in `config.yml`.
Replacing the image in file `templates/docker-compose.yml.j2` is implemented with an if statement based on the speedtest variable in the config file. The original speedtest based on Ookla will always be the default, in case of missing config variable or misspelling.

@geerlingguy, I think that addresses your last comment on closed pull request  #387.

Fixes #341: 

- #341 