### PR TITLE
[Tiny] Made the grafna dashboard more human readable

### DIFF
--- a/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
+++ b/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
@@ -380,7 +380,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "refId": "A"
         }
       ],
@@ -503,7 +503,7 @@
           "expr": "sum(probe_http_duration_seconds) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "refId": "A"
         }
       ],
@@ -595,7 +595,7 @@
           "expr": "speedtest_jitter_latency_milliseconds{}\n",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -689,7 +689,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"connect\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -783,7 +783,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"processing\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -877,7 +877,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"resolve\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -971,7 +971,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"tls\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -1065,7 +1065,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"transfer\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
I just used the existing "humanname" variable which existed but was never used. Now the dashboard contains the human readable form while the backend can cope with the real stuff.

My best guess is, that this was just forgotten.

![image](https://user-images.githubusercontent.com/49672038/224996458-ea48334b-3542-4b0a-b432-8fe38ac302b7.png)
