### PR TITLE
update container tags to :latest

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -15,7 +15,7 @@ networks:
 services:
 {% if domain_name_enable %}
   nginx-proxy:
-    image: nginxproxy/nginx-proxy
+    image: nginxproxy/nginx-proxy:latest
     restart: always
     ports:
       - "80:80"
@@ -23,13 +23,15 @@ services:
       - back-tier
       - front-tier
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
 {% endif %}
 
   prometheus:
-    image: prom/prometheus:v2.25.2
+    image: prom/prometheus:latest
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - ./prometheus/:/etc/prometheus/
       - prometheus_data:/prometheus
     command:
@@ -54,9 +56,10 @@ services:
 {% endif %}
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:latest
     restart: always
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/:/etc/grafana/provisioning/
     depends_on:
@@ -77,41 +80,43 @@ services:
 {% endif %}
 
   ping:
-    tty: true
-    stdin_open: true
+    image: prom/blackbox-exporter:latest
+    restart: always
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./blackbox/config:/config
     expose:
       - 9115
     ports:
       - 9115:9115
-    image: prom/blackbox-exporter
-    restart: always
-    volumes:
-      - ./blackbox/config:/config
+    tty: true
+    stdin_open: true
     command:
       - '--config.file=/config/blackbox.yml'
     networks:
       - back-tier
 
   speedtest:
+    image: miguelndecarvalho/speedtest-exporter:latest
+    restart: always
     expose:
       - 9798
     ports:
       - 9798:9798
-    image: miguelndecarvalho/speedtest-exporter
-    restart: always
     networks:
       - back-tier
 
   nodeexp:
+    image: prom/node-exporter:latest
+    restart: always
     privileged: true
-    image: prom/node-exporter
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
     ports:
       - 9100:9100
-    restart: always
     command:
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'

--- a/templates/pi-hole-docker-compose.yml.j2
+++ b/templates/pi-hole-docker-compose.yml.j2
@@ -14,6 +14,7 @@ services:
   pihole:
     container_name: pihole
     image: pihole/pihole:latest
+    restart: unless-stopped
     hostname: '{{ pihole_hostname }}'
     ports:
       - "53:53/tcp"
@@ -40,6 +41,7 @@ services:
       - 127.0.0.1
       - 8.8.8.8
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - './etc-pihole/:/etc/pihole/'
       - './etc-dnsmasq.d/:/etc/dnsmasq.d/'
     cap_add:
@@ -59,11 +61,11 @@ services:
       - "{{ domain_prometheus }}.{{ domain_name }}:{{ ansible_facts['default_ipv4']['address'] }}"
 {% endif %}
 {% endif %}
-    restart: unless-stopped
 
   pihole-exporter:
     container_name: pihole-exporter
     image: ekofr/pihole-exporter:latest
+    restart: unless-stopped
     hostname: 'pihole-exporter'
     ports:
       - "9617:9617"
@@ -72,4 +74,3 @@ services:
       PIHOLE_PASSWORD: '{{ pihole_password }}'
       INTERVAL: '30s'
       PORT: 9617
-    restart: unless-stopped


### PR DESCRIPTION
added volume: - /etc/localtime:/etc/localtime:ro to syncronize time & timezone to containers
moved image tag to top of container definitions for readability.

resolves: #502 prometheus version

Tested on debian 11.7 micropc and raspberrypi os 20230214 rpi 4b 4g