### PR TITLE
add check for /etc/resolvconf.conf

### DIFF
--- a/example.config.yml
+++ b/example.config.yml
@@ -14,6 +14,7 @@ pihole_enable: true
 pihole_hostname: pihole
 pihole_timezone: America/Chicago
 pihole_password: "change-this-password"
+pihole_update_local_resolveconf: true
 
 # Internet monitoring configuration.
 monitoring_enable: true

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -23,14 +23,21 @@
     build: false
   become: false
 
+# only run if resolvconf.conf exists
+- name: Ensure /etc/resolvconf.conf exists
+  ansible.builtin.stat:
+    path: /etc/resolvconf.conf
+  register: resolvconfconf_exists
+
 - name: Update resolveconf for local name server use.
   ansible.builtin.lineinfile:
     line: "name_servers=127.0.0.1"
-    dest: "/etc/resolvconf.conf"
+    path: "/etc/resolvconf.conf"
     regexp: "^#?name_servers="
   register: resolvconf_file
+  when: pihole_update_local_resolveconf is true and resolvconfconf_exists.stat.exists
 
 - name: Regenerate resolvconf if file is changed.
   ansible.builtin.command: resolvconf -u
   changed_when: false
-  when: resolvconf_file is changed
+  when: resolvconf_file is changed and resolvconfconf_exists.stat.exists


### PR DESCRIPTION
add option to diable /etc/resolvconf.conf update

ansible facts /etc/os_release /etc/debian_version don't differentiate debian vrs raspberrypi os, so test if /etc/resolvconf.conf file exists and update if it exists

Fixes #520 
tested deploying on debian 11.7 micropc and raspberrypi os 20230214 rpi 4b 4g