### PR TITLE
Add blackbox icmp module that prefers ipv4

### DIFF
--- a/internet-monitoring/blackbox/config/blackbox.yml
+++ b/internet-monitoring/blackbox/config/blackbox.yml
@@ -34,3 +34,7 @@ modules:
         - expect: "^:[^ ]+ 001"
   icmp:
     prober: icmp
+  icmp_ipv4:
+    prober: icmp
+    icmp:
+      preferred_ip_protocol: ip4


### PR DESCRIPTION
On a device without a fully-functioning ipv6 stack, icmp pings may fail. This is described well here:

https://www.robustperception.io/icmp-pings-with-the-blackbox-exporter/

and can be debugged at:

`internet-pi-host:9115/probe?module=icmp&target=google.com&debug=true`

This patch adds support for an ipv4-specific icmp probe:

`internet-pi-host:9115/probe?module=icmp_ipv4&target=google.com&debug=true`