### PR TITLE
Set Grafana allowUiUpdates, letting users save dashboards

### DIFF
--- a/internet-monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/internet-monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -8,5 +8,6 @@ providers:
     type: file
     disableDeletion: false
     editable: true
+    allowUiUpdates: true
     options:
       path: /etc/grafana/provisioning/dashboards


### PR DESCRIPTION
In the current configuration, dashboards are immutable. This allows users to save changes to the pre-built internet-connections dashboard, and create new dashboards without forking this project.