### PR TITLE
Grafana fixed version 8.4.3-armv7

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -56,7 +56,7 @@ services:
 {% endif %}
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:8.4.3-armv7
     restart: always
     volumes:
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
Grafana have paused armv6/7, the lastest armv7 - [Grafana blog][blog].
[10.1.2][10.1.2] supports v7, there is also a specific version [8.4.3-armv7][8.4.3]


[blog]: https://grafana.com/blog/2023/09/29/grafana-and-grafana-enterprise-updates-for-armv6-and-armv7-will-be-temporarily-paused/
[8.4.3]: https://hub.docker.com/r/grafana/grafana/tags?page=1&name=armv7
[10.1.2]: https://hub.docker.com/layers/grafana/grafana/10.1.2/images/sha256-80b7e6a6451036c604fb0cb9294dbb5b63058db80b1a3b838cb5f80cf7c8c362?context=explore