### PR TITLE
Resolve dependency issues from Debian Bookwrom and improve resolvconf update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It should also work with Ubuntu for Pi, or Arch Linux, but has not been tested o
 ## Setup
 
   1. [Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html). The easiest way (especially on Pi or a Debian system) is via Pip:
-     1. (If on Pi/Debian): `sudo apt-get install -y python3-pip`
+     1. (If on Pi/Debian): `sudo apt-get install -y ansible`
      2. (Everywhere): `pip3 install ansible`
   2. Clone this repository: `git clone https://github.com/geerlingguy/internet-pi.git`, then enter the repository directory: `cd internet-pi`.
   3. Install requirements: `ansible-galaxy collection install -r requirements.yml` (if you see `ansible-galaxy: command not found`, restart your SSH session or reboot the Pi and try again)
@@ -56,7 +56,7 @@ It should also work with Ubuntu for Pi, or Arch Linux, but has not been tested o
 
 ### Pi-hole
 
-Visit the Pi's IP address (e.g. http://192.168.1.10/) and use the `pihole_password` you configured in your `config.yml` file. An existing pi-hole installation can be left unaltered by disabling the setup of this proyect's installation in your `config.yml` (`pihole_enable: false`)
+Visit the Pi's IP address (e.g. http://192.168.1.10/admin) and use the `pihole_password` you configured in your `config.yml` file. An existing pi-hole installation can be left unaltered by disabling the setup of this project's installation in your `config.yml` (`pihole_enable: false`)
 
 ### Grafana
 

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -34,6 +34,8 @@
       - python3-pip
       - git
       - rsync
+      - docker-compose
+      - resolvconf
     state: present
   when: ansible_facts.os_family == "Debian"
 
@@ -46,14 +48,9 @@
       - python-pip
       - git
       - rsync
+      - docker-compose
     state: present
   when: ansible_facts.os_family == "Archlinux"
-
-- name: Install Docker Compose using Pip.
-  ansible.builtin.pip:
-    name: docker-compose
-    state: present
-    executable: pip3
 
 - name: "Ensure user is added to the docker group: {{ ansible_user }}"
   ansible.builtin.user:

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -27,6 +27,7 @@
   ansible.builtin.file:
     path: "/etc/resolvconf.conf"
     state: touch
+  become: false
 
 - name: Update resolveconf for local name server use.
   ansible.builtin.lineinfile:

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -23,6 +23,11 @@
     build: false
   become: false
 
+- name: Ensure resolveconf exists.
+  ansible.builtin.file:
+    path: "/etc/resolvconf.conf"
+    state: touch
+
 - name: Update resolveconf for local name server use.
   ansible.builtin.lineinfile:
     line: "name_servers=127.0.0.1"

--- a/tasks/pi-hole.yml
+++ b/tasks/pi-hole.yml
@@ -27,7 +27,7 @@
   ansible.builtin.file:
     path: "/etc/resolvconf.conf"
     state: touch
-  become: false
+    mode: "744"
 
 - name: Update resolveconf for local name server use.
   ansible.builtin.lineinfile:


### PR DESCRIPTION
This PR primarily intends to fix [a problem that was introduced in Debian Bookworm](https://github.com/geerlingguy/internet-pi/issues/564), which broke the Ansible playbook. While setting this up on a Pi with the latest image, I was able to troubleshoot the `pip` dependency issues and replace them with `apt`. Additionally, my Pi did not have `resolvconf` installed which caused Ansible to blow up, so I added that to the Debian dependencies, and also used Ansible to create the `resolvconf.conf` file if it does not exist. Finally, I made a few tweaks in the README to fix a typo, reflect the current admin portal for Pihole, and update the setup instructions to fix the `pip` issue.

# Note
* I did not test this with Arch so I did not add `resolvconf` to the `pacman` dependencies, although it may need to be added there as well. It looks like Arch / pacman [has docker-compose](https://archlinux.org/packages/extra/x86_64/docker-compose/) too
* I tested this through trial and error with my own Pi running the latest Raspberry Pi OS based on Debian Bookworm. After these changes it looks like everything is up and running