### PR TITLE
change position when checking if domain name enabled

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -64,6 +64,12 @@ services:
       - ./grafana/provisioning/:/etc/grafana/provisioning/
     depends_on:
       - prometheus
+{% if domain_name_enable and domain_name and domain_grafana %}
+      - nginx-proxy
+    environment:
+      - VIRTUAL_HOST={{ domain_grafana }}.{{ domain_name }}
+      - VIRTUAL_PORT=3000
+{% endif %}
     ports:
       - 3030:3000
     env_file:
@@ -71,13 +77,6 @@ services:
     networks:
       - back-tier
       - front-tier
-{% if domain_name_enable and domain_name and domain_grafana %}
-    depends_on:
-      - nginx-proxy
-    environment:
-      - VIRTUAL_HOST={{ domain_grafana }}.{{ domain_name }}
-      - VIRTUAL_PORT=3000
-{% endif %}
 
   ping:
     image: prom/blackbox-exporter:latest


### PR DESCRIPTION
Current compose file will resulting error:
`{"changed": false, "cmd": "/usr/bin/docker --host unix:///var/run/docker.sock compose --ansi never --progress plain --project-directory /home/pi/internet-monitoring/ ps --format json --all --no-trunc", "msg": "yaml: unmarshal errors:\n  line 70: mapping key \"depends_on\" already defined at line 61", "rc": 15, "stderr": "yaml: unmarshal errors:\n  line 70: mapping key \"depends_on\" already defined at line 61\n", "stderr_lines": ["yaml: unmarshal errors:", "  line 70: mapping key \"depends_on\" already defined at line 61"], "stdout": "", "stdout_lines": []}`

since `depends_on` is being declared twice. I fixed it on my pi with this