### PR TITLE
Update docker-compose.yml.j2

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -6,9 +6,9 @@ volumes:
 
 networks:
   front-tier:
-    name: internet-monitoring-front-tier
+    name: front-tier
   back-tier:
-    name: internet-monitoring-back-tier
+    name: back-tier
 
 services:
 {% if domain_name_enable %}


### PR DESCRIPTION
Modified front-tier and back-tier network names since install will fail without these names modified. Should be a fix for issue #619