### PR TITLE
Update README.md with instructions to add user to `docker` group

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ It should also work with Ubuntu for Pi, or Arch Linux, but has not been tested o
      - `example.config.yml` to `config.yml`
   5. Run the playbook: `ansible-playbook main.yml`
 
-> **If running locally on the Pi**: You may encounter an error like "Error while fetching server API version" or "connect: permission denied". If you do, please either reboot or log out and log back in, then run the playbook again.
+> **If running locally on the Pi**: You may encounter an error like "Error while fetching server API version" or "connect: permission denied". If you do, please either reboot or log out and log back in, then run the playbook again. If you continue to receive a "permission denied while trying to connect to the Docker daemon socket" error, then you may need to first add your user to the `docker` user group: `sudo usermod -aG docker $USER`, as outlined in the [Docker documentation](https://docs.docker.com/engine/install/linux-postinstall/).
 
 ## Usage
 


### PR DESCRIPTION
When setting up my Internet Pi on my Raspberry Pi 5, I encountered the `permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock` error described in #620 when running `ansible-playbook main.yml`. Following the suggestion to add the Raspberry Pi user to the `docker` user group (via `sudo usermod -aG docker $USER`) fixed the issue and allowed `ansible-playbook main.yml` to run successfully.

This adds a note about this fix to the installation instructions in `README.md`. It might also be better to just add this as an explicit step in the setup process if everyone will need to be doing this now.