### PR TITLE
Configure FTL dns_listeningMode and dns_interface variables

### DIFF
--- a/templates/pi-hole-docker-compose.yml.j2
+++ b/templates/pi-hole-docker-compose.yml.j2
@@ -29,6 +29,8 @@ services:
       TZ: '{{ pihole_timezone }}'
       FTLCONF_webserver_api_password: '{{ pihole_password }}'
       FTLCONF_dns_reply_host_IPv4: '{{ ansible_facts['default_ipv4']['address'] }}'
+      FTLCONF_dns_listeningMode: 'SINGLE'
+      FTLCONF_dns_interface: '{{ ansible_facts['default_ipv4']['interface'] }}'
 {% if domain_name_enable and domain_name and domain_pihole %}
       VIRTUAL_HOST: {{ domain_pihole }}.{{ domain_name }}
       VIRTUAL_PORT: 80


### PR DESCRIPTION
It seems current repo's code does not work well with pihole v6. The container config is missing a couple of variables to configure Pihole/DNSMASQ interface to listen on.

Docs are not super clear but it seems we have to configure them to make it work from a container https://docs.pi-hole.net/docker/

Before the patch:
```
root@raspberrypi:~/internet-pi# nslookup home.local localhost
Server:         localhost
Address:        127.0.0.1#53

Name:   home.local
Address: 192.168.1.101

root@raspberrypi:~/internet-pi# nslookup home.local 192.168.1.101
;; communications error to 192.168.1.101#53: connection refused
;; communications error to 192.168.1.101#53: connection refused
;; communications error to 192.168.1.101#53: connection refused
;; no servers could be reached
```

After applying this fix:
```
root@raspberrypi:~/internet-pi# nslookup home.local 192.168.1.101
Server:         192.168.1.101
Address:        192.168.1.101#53

Name:   home.local
Address: 192.168.1.101
```