### PR TITLE
Fix pihole-exporter configuration

### DIFF
--- a/templates/pi-hole-docker-compose.yml.j2
+++ b/templates/pi-hole-docker-compose.yml.j2
@@ -1,12 +1,17 @@
 # {{ ansible_managed }}
 ---
+networks:
 {% if domain_name_enable and domain_name and domain_pihole %}
 {# Make sure pihole and nginx-proxy are in the same network #}
-networks:
   front-tier:
     name: internet-monitoring-front-tier
     external: true
 {% endif %}
+{# pihole and pihole-exporter need to share network with Prometheus #}
+  back-tier:
+    name: internet-monitoring-back-tier
+    external: true
+
 
 # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:
@@ -35,7 +40,10 @@ services:
       VIRTUAL_HOST: {{ domain_pihole }}.{{ domain_name }}
       VIRTUAL_PORT: 80
       PROXY_LOCATION: {{ domain_pihole }}
+{% endif %}
     networks:
+      - back-tier
+{% if domain_name_enable and domain_name and domain_pihole %}
       - front-tier
 {% endif %}
     dns:
@@ -68,6 +76,8 @@ services:
     image: ekofr/pihole-exporter:latest
     restart: unless-stopped
     hostname: 'pihole-exporter'
+    networks:
+      - back-tier
     ports:
       - "9617:9617"
     environment:

--- a/templates/prometheus.yml.j2
+++ b/templates/prometheus.yml.j2
@@ -78,7 +78,7 @@ scrape_configs:
 {% if pihole_enable %}
   - job_name: '{{ pihole_hostname }}'
     static_configs:
-      - targets: ['{{ pihole_hostname }}:9617']
+      - targets: ['pihole-exporter:9617']
 {% endif %}
 
 {% filter indent(width=2,first=True) %}


### PR DESCRIPTION
- target was not set correctly: target should be `pihole-exporter` container and not `pihole`
- pihole and pihole-exporter need to share the same network, otherwise the usage metrics cannot be accessed by the exporter