### PR TITLE
Update legend format in internet connection dashboard to use human-readable names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 inventory.ini
 config.yml
 .DS_Store
+.vscode

--- a/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
+++ b/internet-monitoring/grafana/provisioning/dashboards/internet-connection.json
@@ -396,7 +396,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "refId": "A"
         }
       ],
@@ -496,7 +496,7 @@
           "expr": "sum(probe_http_duration_seconds) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "refId": "A"
         }
       ],
@@ -589,7 +589,7 @@
           "expr": "speedtest_jitter_latency_milliseconds{}\n",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -683,7 +683,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"connect\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -777,7 +777,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"processing\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -871,7 +871,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"resolve\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -965,7 +965,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"tls\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }
@@ -1059,7 +1059,7 @@
           "expr": "sum(probe_http_duration_seconds{phase=\"transfer\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{instance}}",
+          "legendFormat": "{{humanname}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
Forgive me if this is incorrect but as far as I could see the `humanname` variable from Prometheus was unused so I updated internet-connection.json to show the pretty names in place of the urls when showing the ping results.

I also added the .vscode folder to gitignore to help with development.
